### PR TITLE
Add Database Name to Connection Options

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -26,6 +26,7 @@ async function dbConnect() {
   if (!cached.promise) {
     const opts = {
       bufferCommands: false,
+      dbName: 'blog',
     };
 
     cached.promise = mongoose.connect(MONGODB_URI, opts).then((mongoose) => {


### PR DESCRIPTION
- Set the database name to 'blog' in the dbConnect function to ensure proper connection to the intended database.